### PR TITLE
Require bundle output name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ gulp.task('elm', ['elm-init'], function(){
     .pipe(elm())
     .pipe(gulp.dest('dist/'));
 });
+
+gulp.task('elm-bundle', ['elm-init'], function(){
+  return gulp.src('src/*.elm')
+    .pipe(elm.bundle('bundle.js'))
+    .pipe(gulp.dest('dist/'));
+});
 ```
 
 API
@@ -25,6 +31,12 @@ API
 execute `elm-make --yes`.
 
 If you compile multi file, all elm tasks depends on elm.init task.
+
+#### options
+
+* elmMake (default: "elm-make")
+
+    elm-make executable file.
 
 ### `elm` / `elm.make`
 
@@ -46,14 +58,22 @@ compile elm files.
 
     js(javascript) or html.
 
-### `bundle`
+### `elm.bundle`
 
 compile and bundle elm files into a single file.
 
+#### arguments
+
+* output
+
+    you must pass the name of the output file
+
 #### options
 
-* output (default: "bundle.js")
+* yesToAllPrompts (default: true)
 
-    set the output file name for the --output option to elm-make.
+    add --yes option to elm-make.
 
-and all available options from `elm` / `elm.make`
+* elmMake (default: "elm-make")
+
+    elm-make executable file.

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var gutil         = require('gulp-util')
   , defaultArgs   = ['--yes']
   , PLUGIN        = 'gulp-elm';
 
-function processMakeOptions(options) {
+function processMakeOptions(options, output) {
   var args   = defaultArgs
   , ext    = '.js'
   , exe    = elm_make;
@@ -30,6 +30,8 @@ function processMakeOptions(options) {
       if(ft === 'js' || ft === 'javascript') { ext = '.js'; }
       else if (ft == 'html') { ext = '.html'; }
       else { throw new gutil.PluginError(PLUGIN, 'filetype is js or html.'); }
+
+      if (output && path.extname(output) !== ext) { throw new gutil.PluginError(PLUGIN, 'output is ' + path.extname(output) + ', but filetype is ' + ext); }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "https://github.com/philopon/gulp-elm"
   },
   "author": {
     "name": "philopon",

--- a/test/main.js
+++ b/test/main.js
@@ -78,4 +78,17 @@ describe('gulp-elm', function(){
     });
   });
 
+  it('should error when output does not match filetype.', function(){
+    var output = "bundle.js";
+    try {
+      var myElm = elm.bundle(output, {filetype: 'html'});
+    } catch (error) {
+      assert(error);
+      assert.equal(error.plugin, 'gulp-elm');
+      return;
+    }
+
+    assert.fail('Should have thrown exception');
+  });
+
 });

--- a/test/main.js
+++ b/test/main.js
@@ -68,7 +68,7 @@ describe('gulp-elm', function(){
 
   it('should bundle Elm files to js from virtual file.', function(done){
     var output = "bundle.js";
-    var myElm = elm.bundle({output: output});
+    var myElm = elm.bundle(output);
     myElm.write(new gutil.File({path: "test/test1.elm", contents: fs.readFileSync('test/test1.elm')}));
     myElm.end(new gutil.File({path: "test/test2.elm", contents: fs.readFileSync('test/test2.elm')}));
     myElm.once('data', function(file){


### PR DESCRIPTION
Looking at plugins like `gulp-concat`, I think it feels more "gulpy" to have the output file name be required, rather than an option.

I also added an error if a `filetype` option is passed in and it doesn't match the output extension.
